### PR TITLE
Single family home neighborhoods are no longer middle class

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 
 
 	<div class="App">
-	
+
 		<div id='act-now-modal' class='modal' style="position:fixed">
 			<div class="modal-content-container">
 				<div class="modal-content" id="act-now-modal-content">
@@ -59,7 +59,7 @@
 					<div class="modal-body">
 						<div>
 							<h3 style="text-align: center;font-size:20px">Act Now to oppose SB 50</h3>
-							
+
 							<p>
 								<b>CALL and EMAIL the most important STATE SENATORS (listed at bottom). USE your own words with help from one of the scripts below!</b>
 							</p>
@@ -69,28 +69,28 @@
 							</p>
 							<ol>
 								<li style="padding-bottom:20px;font-style:italic;line-height:1.5">
-									“My name is ___. I live in your district. I’m calling about SB 50. As my representative, I urge you to oppose this bill. SB 50 will bring severe displacement and 
-									gentrification and HURT the poor and working-class, and wipe out thousands of middle-class single-family-home neighborhoods. In our district, developers could decimate 
-									areas like (fill in your area). SB 50 strips city zoning and planning powers in <font style="text-decoration: underline"> neighborhoods near bus or rail stops</font>, 
+									“My name is ___. I live in your district. I’m calling about SB 50. As my representative, I urge you to oppose this bill. SB 50 will bring severe displacement and
+									gentrification and HURT the poor and working-class, and wipe out thousands of (formerly) middle-class single-family-home neighborhoods. In our district, developers could decimate
+									areas like (fill in your area). SB 50 strips city zoning and planning powers in <font style="text-decoration: underline"> neighborhoods near bus or rail stops</font>,
 									letting developers go as high as 8 stories. The heart of this bill is demolition of housing. Our community will never recover.”
 								</li>
 								<li style="padding-bottom:20px;font-style:italic;line-height:1.5">
-									“My name is ___. I live in your district. I’m calling about SB 50. As my representative, I urge you to oppose this bill. If SB 50 isn’t killed, my city (name) 
-									<font style="text-decoration: underline">can only reject 6-to 8 story luxury towers in transit zones or “job rich” zones if the project “harms public safety." 
-									Developers get to leave out parking entirely and wipe out green belts, side yards and setbacks where children play.</font> This means destruction of single-family 
+									“My name is ___. I live in your district. I’m calling about SB 50. As my representative, I urge you to oppose this bill. If SB 50 isn’t killed, my city (name)
+									<font style="text-decoration: underline">can only reject 6-to 8 story luxury towers in transit zones or “job rich” zones if the project “harms public safety."
+									Developers get to leave out parking entirely and wipe out green belts, side yards and setbacks where children play.</font> This means destruction of single-family
 									AND rental housing to make way for luxury one-bedrooms, forcing families further from jobs. Imagine the nightmare, and oppose SB 50.”
 								</li>
 								<li style="font-style:italic;line-height:1.5">
-									“My name is ___. I live in your district. I’m calling about SB 50. As my representative, I urge you to oppose this bill. One-size-fits-all thinking doesn’t work. 
-									SB 50 is a real estate bill, not a housing solution. Senator Wiener’s YIMBY base calls single family homes ‘racist’ and ‘immoral.’ Rather than solving the housing problem, 
+									“My name is ___. I live in your district. I’m calling about SB 50. As my representative, I urge you to oppose this bill. One-size-fits-all thinking doesn’t work.
+									SB 50 is a real estate bill, not a housing solution. Senator Wiener’s YIMBY base calls single family homes ‘racist’ and ‘immoral.’ Rather than solving the housing problem,
 									SB 50 promotes demotion, displacement, gentrification, and deepening income inequity.”
 								</li>
 							</ol>
 							</br></br>
-							
+
 							<hr>
 							<h3 style="text-align: center;font-size:20px">Get further info!</h3>
-							
+
 							What does SB50 do? Read more at the links below.
 							<ul>
 								<li>
@@ -104,15 +104,15 @@
 								</li>
 							</ul>
 							</br></br>
-							
+
 							<hr>
 							<h3 style="text-align: center;font-size:20px">CALL and EMAIL your message to the below KEY SENATORS</h3>
-							
+
 							If the senator's email doesn't work, please use the email form on their website.<br><br>
 							<div class="row">
 								<div class="column">
 									<b>State Senate Housing Committee</b></br></br>
-			
+
 									<a href="https://senate.ca.gov/sd11" target="_blank">Senator Scott D. Wiener (Chair)</a></br>
 									<a href="mailto:senator.wiener@senate.ca.gov" target="_blank">senator.wiener@senate.ca.gov</a></br>
 									Phone: (916) 651-4011</br>
@@ -159,12 +159,12 @@
 									</br>
 									<a href="https://senate.ca.gov/sd10" target="_blank">Senator Bob Wieckowsk</a></br>
 									<a href="mailto:senator.wieckowski@senate.ca.gov" target="_blank">senator.wieckowski@senate.ca.gov</a></br>
-									Phone: (916) 651-4010</br>	
+									Phone: (916) 651-4010</br>
 								</div>
-									
+
 								<div class="column">
 									<b>Senate Governance and Finance Committee</b></br></br>
-									
+
 									<a href="https://senate.ca.gov/sd02" target="_blank">Senator Mike McGuire (Chair)</a></br>
 									<a href="mailto:senator.mcguire@senate.ca.gov" target="_blank">senator.mcguire@senate.ca.gov</a></br>
 									Phone: 916-651-4002</br>
@@ -193,17 +193,17 @@
 									<a href="mailto:senator.wiener@senate.ca.gov" target="_blank">senator.wiener@senate.ca.gov</a></br>
 									Phone: (916) 651-4011</br>
 									</br>
-									
-									
+
+
 								</div>
 							</div>
-							
+
 						</div>
 					</div>
 				</div>
 			</div>
 		</div>
-	
+
 		<div id='tos-modal' class='modal' style="position:fixed">
 			<div class="modal-content-container">
 				<div class="modal-content" id="tos-modal-content">
@@ -212,17 +212,17 @@
 						<div>
 							</br>
 							<p>
-								Welcome and thank you for your interest in this website which is sponsored by Coalition to Preserve LA and Livable California (collectively, "Sponsor"). By using this website or any 
-								other services provided by Sponsor (collectively, the “Services”), or accessing any content provided by Sponsor through the Services, you agree to be bound by the following terms of use, 
+								Welcome and thank you for your interest in this website which is sponsored by Coalition to Preserve LA and Livable California (collectively, "Sponsor"). By using this website or any
+								other services provided by Sponsor (collectively, the “Services”), or accessing any content provided by Sponsor through the Services, you agree to be bound by the following terms of use,
 								as updated from time to time ("Terms of Use").
 							</p>
 							<p>
-								<b>1. Sponsor Role.</b> SPONSOR DOES NOT, AND THE SERVICES ARE NOT INTENDED TO, PROVIDE FINANCIAL OR REAL ESTATE ADVICE. SPONSOR IS NOT A FINANCIAL OR REAL ESTATE BROKER OR LENDER. Sponsor assumes 
-								no responsibility for any result or consequence related directly or indirectly to any action or inaction that consumers take based on the Services or any other information available through 
+								<b>1. Sponsor Role.</b> SPONSOR DOES NOT, AND THE SERVICES ARE NOT INTENDED TO, PROVIDE FINANCIAL OR REAL ESTATE ADVICE. SPONSOR IS NOT A FINANCIAL OR REAL ESTATE BROKER OR LENDER. Sponsor assumes
+								no responsibility for any result or consequence related directly or indirectly to any action or inaction that consumers take based on the Services or any other information available through
 								or in connection with the Services.
 							</p>
 							<p>
-								<b>2. Use of the Services; Restrictions.</b> As long as you comply with these Terms of Use, Sponsor grants you a non-exclusive, limited, revocable, personal, non-transferable license to use the Services, 
+								<b>2. Use of the Services; Restrictions.</b> As long as you comply with these Terms of Use, Sponsor grants you a non-exclusive, limited, revocable, personal, non-transferable license to use the Services,
 								for your personal use. The Services may not be used for transactions in real estate.
 							</p>
 							<p>
@@ -232,7 +232,7 @@
 										use information provided by Sponsor through the Services in making any loan-related decisions;
 									</li>
 									<li>
-										reproduce, modify, distribute, display or otherwise provide access to, create derivative works from, decompile, disassemble, or reverse engineer any portion of the Services, except as 
+										reproduce, modify, distribute, display or otherwise provide access to, create derivative works from, decompile, disassemble, or reverse engineer any portion of the Services, except as
 										explicitly permitted under these Terms of Use;
 									</li>
 									<li>
@@ -251,8 +251,8 @@
 										impersonate another person or misrepresent your affiliation with another person or entity;
 									</li>
 									<li>
-										reproduce, publicly display, or otherwise make accessible on or through any other Web site, application, or service any reviews, ratings, and/or profile information about real estate, 
-										lending, or other professionals, underlying images of or information about real estate listings, or other data or content available through the Services, except as explicitly permitted 
+										reproduce, publicly display, or otherwise make accessible on or through any other Web site, application, or service any reviews, ratings, and/or profile information about real estate,
+										lending, or other professionals, underlying images of or information about real estate listings, or other data or content available through the Services, except as explicitly permitted
 										by Sponsor for a particular portion of the Services;
 									</li>
 									<li>
@@ -262,7 +262,7 @@
 										interfere with, or compromise the system integrity or security of the Services, or otherwise bypass any measures Sponsor may use to prevent or restrict access to the Services;
 									</li>
 									<li>
-										conduct automated queries (including screen and database scraping, spiders, robots, crawlers, bypassing “captcha” or similar precautions, and any other automated activity with 
+										conduct automated queries (including screen and database scraping, spiders, robots, crawlers, bypassing “captcha” or similar precautions, and any other automated activity with
 										the purpose of obtaining information from the Services) on the Services;
 									</li>
 									<li>
@@ -274,9 +274,9 @@
 								</ol>
 							</p>
 							<p>
-								<b>4. Intellectual Property.</b> The Services are owned and operated by Sponsor. Data used in the Services may include publicly-available data or privately-generated data. The user interfaces, 
-								design, information, data, code, products, software, graphics, and all other elements of the Services (“Sponsor Materials”) provided by Sponsor are protected by intellectual property and 
-								other laws and are the property of Sponsor or Sponsor third-party licensors. Except as expressly allowed by these Terms of Use, you may not make use of the Sponsor Materials, and Sponsor 
+								<b>4. Intellectual Property.</b> The Services are owned and operated by Sponsor. Data used in the Services may include publicly-available data or privately-generated data. The user interfaces,
+								design, information, data, code, products, software, graphics, and all other elements of the Services (“Sponsor Materials”) provided by Sponsor are protected by intellectual property and
+								other laws and are the property of Sponsor or Sponsor third-party licensors. Except as expressly allowed by these Terms of Use, you may not make use of the Sponsor Materials, and Sponsor
 								reserves all rights to the Sponsor Materials and Services not granted expressly in these Terms of Use.
 
 							</p>
@@ -284,27 +284,27 @@
 								<b>Intellectual Property Notices:</b>
 							</p>
 							<p>
-								Certain content on the Services is owned by other Sponsors or is public data. The names of actual companies, products, and services mentioned herein may be the trademarks of their respective 
-								owners. Any rights not expressly granted herein are reserved. Sponsor does not assert copyright or grant any rights to the underlying images or descriptions of real estate listings provided 
+								Certain content on the Services is owned by other Sponsors or is public data. The names of actual companies, products, and services mentioned herein may be the trademarks of their respective
+								owners. Any rights not expressly granted herein are reserved. Sponsor does not assert copyright or grant any rights to the underlying images or descriptions of real estate listings provided
 								through the Services. Any use of these images and descriptions is subject to the copyright owner's permission and the requirements of applicable law.
 							</p>
 							<p>
-								<b>5. DMCA; Claims of Copyright Infringement.</b> Sponsor respects the intellectual property rights of others, and asks that everyone using the Services do the same. Anyone who believes that their 
-								work has been reproduced on the Services in a way that constitutes copyright infringement may notify Sponsor copyright agent in accordance with Title 17, United States Code, Section 512(c)(2), 
+								<b>5. DMCA; Claims of Copyright Infringement.</b> Sponsor respects the intellectual property rights of others, and asks that everyone using the Services do the same. Anyone who believes that their
+								work has been reproduced on the Services in a way that constitutes copyright infringement may notify Sponsor copyright agent in accordance with Title 17, United States Code, Section 512(c)(2),
 								by providing the following information:
 								<ol type="A">
 									<li>
 										Identification of the copyrighted work that you claim has been infringed;
 									</li>
 									<li>
-										Identification of the material that you claim is infringing and needs to be removed, including a description of where it is located on the Services so that the copyright agent can 
+										Identification of the material that you claim is infringing and needs to be removed, including a description of where it is located on the Services so that the copyright agent can
 										locate it;
 									</li>
 									<li>
 										Your address, telephone number, and, if available, e-mail address, so that the copyright agent may contact you about your complaint; and
 									</li>
 									<li>
-										A signed statement that the above information is accurate; that you have a good faith belief that the identified use of the material is not authorized by the copyright owner, its 
+										A signed statement that the above information is accurate; that you have a good faith belief that the identified use of the material is not authorized by the copyright owner, its
 										agent, or the law; and, under penalty of perjury, that you are the copyright owner or are authorized to act on the copyright owner's behalf in this situation.
 									</li>
 								</ol>
@@ -318,89 +318,89 @@
 								Attention: Copyright Agent</br></br>
 								<b>By e-mail:</b> <a href= "mailto: contact@livableca.org" target="_blank">contact@livableca.org</a><br>
 								<br>
-								If you give notice of copyright infringement by e-mail, we may begin investigating the alleged copyright infringement; however, we must receive your signed statement by mail or as an attachment 
+								If you give notice of copyright infringement by e-mail, we may begin investigating the alleged copyright infringement; however, we must receive your signed statement by mail or as an attachment
 								to your e-mail before we are required to take any action.
 							</p>
-							
+
 							<p>
-								<b>6.Termination/Changes to Agreement.</b> Sponsor may in its sole discretion terminate your account on the Services or suspend or terminate your access to the Services at any time for any reason, with 
-								or without notice. Sponsor may alter, suspend or discontinue the Services or any portion of the Services without notice. Sponsor will not be liable whatsoever for any change to the Services or any 
-								suspension or termination of your access to or use of the Services. Sponsor reserves the right to change these Terms of Use at any time in its sole discretion on a going-forward basis. We will make 
-								commercially reasonable efforts to notify you of any material changes to these Terms of Use. Your continued use of the Services after updates are effective will represent your agreement to the 
-								revised version of these Terms of Use. Your continued use of the Services after the effectiveness of such changes will constitute acceptance of and agreement to any such changes. You further waive 
+								<b>6.Termination/Changes to Agreement.</b> Sponsor may in its sole discretion terminate your account on the Services or suspend or terminate your access to the Services at any time for any reason, with
+								or without notice. Sponsor may alter, suspend or discontinue the Services or any portion of the Services without notice. Sponsor will not be liable whatsoever for any change to the Services or any
+								suspension or termination of your access to or use of the Services. Sponsor reserves the right to change these Terms of Use at any time in its sole discretion on a going-forward basis. We will make
+								commercially reasonable efforts to notify you of any material changes to these Terms of Use. Your continued use of the Services after updates are effective will represent your agreement to the
+								revised version of these Terms of Use. Your continued use of the Services after the effectiveness of such changes will constitute acceptance of and agreement to any such changes. You further waive
 								any right you may have to receive specific notice of such changes to these Terms of Use. You are responsible for regularly reviewing these Terms of Use.
 							</p>
 							<p>
-								<b>7. Other Terms.</b> Your use of the Services is subject to all additional guidelines, rules, and agreements applicable to the Services or certain features of the Services that we may post on, or link to, 
+								<b>7. Other Terms.</b> Your use of the Services is subject to all additional guidelines, rules, and agreements applicable to the Services or certain features of the Services that we may post on, or link to,
 								from the Services, such as rules applicable to a particular product or content available through the Services, All such terms are incorporated into, and made a part of, these Terms of Use
 							</p>
 							<p>
-								<b>8. Indemnification.</b> You agree to indemnify, defend, and hold harmless Sponsor, its affiliates, its funders, and their respective directors, officers, employees, and agents from any and 
-								all claims and demands made by any third party due to or arising out of: (a) your access to or use of the Services; (b) your breach of these Terms of Use; (c) your violation of any law or the 
-								rights of a third party; (d) any dispute or issue between you and any third party; (e) any User Materials you upload to, or otherwise make available through, the Services; (f) your willful 
-								misconduct; and (g) any other party’s access to and/or use of the Services using your account and password. Sponsor reserves the right, at its own expense, to assume the exclusive defense and 
+								<b>8. Indemnification.</b> You agree to indemnify, defend, and hold harmless Sponsor, its affiliates, its funders, and their respective directors, officers, employees, and agents from any and
+								all claims and demands made by any third party due to or arising out of: (a) your access to or use of the Services; (b) your breach of these Terms of Use; (c) your violation of any law or the
+								rights of a third party; (d) any dispute or issue between you and any third party; (e) any User Materials you upload to, or otherwise make available through, the Services; (f) your willful
+								misconduct; and (g) any other party’s access to and/or use of the Services using your account and password. Sponsor reserves the right, at its own expense, to assume the exclusive defense and
 								control of any matter otherwise subject to indemnification by you, and in that case, you agree to corporate with Sponsor ‘s defense of that claim.
 							</p>
 							<p>
-								<b>9. No Warranties.</b> SPONSOR PROVIDES THE SERVICES "AS IS," "WITH ALL FAULTS" AND "AS AVAILABLE," AND THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU. 
-								TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SPONSOR AND ITS SUPPLIERS MAKE NO REPRESENTATIONS, WARRANTIES OR CONDITIONS, EXPRESS OR IMPLIED. SPONSOR AND ITS SUPPLIERS EXPRESSLY DISCLAIM 
-								ANY AND ALL WARRANTIES OR CONDITIONS, EXPRESS, STATUTORY AND IMPLIED, INCLUDING WITHOUT LIMITATION: (A) WARRANTIES OR CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, WORKMANLIKE 
-								EFFORT, ACCURACY, TITLE, QUIET ENJOYMENT, NO ENCUMBRANCES, NO LIENS AND NON-INFRINGEMENT; (B) WARRANTIES OR CONDITIONS ARISING THROUGH COURSE OF DEALING OR USAGE OF TRADE; AND (C) WARRANTIES OR 
-								CONDITIONS OF UNINTERRUPTED OR ERROR-FREE ACCESS OR USE. NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU THROUGH THE SERVICES OR ANY MATERIALS AVAILABLE THROUGH THE SERVICES 
-								WILL CREATE ANY WARRANTY REGARDING ANY SPONSOR ENTITY OR THE SERVICES THAT IS NOT EXPRESSIVELY STATED IN THESE TERMS OF USE. YOU ASSUME ALL RISK FOR ANY DAMAGE THAT MAY RESULT FROM YOUR USE OF 
-								OR ACCESS TO THE SERVICES, YOUR DEALING WITH ANY OTHER USER, AND ANY MATERIALS, INCLUDING ALL USER AND SPONSOR MATERIALS, AVAILABLE THROUGH THE SERVICES. YOU UNDERSTAND AND AGREE THAT YOUR USE 
-								OF THE SERVICES, AND USE, ACCESS, DOWNLOAD, OR OTHERWISE OBTAINMENT OF MATERIALS THROUGH THE SERVICES AND ANY ASSOCIATED SITES OR SERVICES, ARE AT YOUR OWN DISCRETION AND RISK, AND THAT YOU ARE 
-								SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR PROPERTY (INCLUDING YOUR COMPUTER SYSTEM OR MOBILE DEVICE USED IN CONNECTION WITH THE SERVICES), OR THE LOSS OF DATA THAT RESULTS FROM THE USE OF THE 
+								<b>9. No Warranties.</b> SPONSOR PROVIDES THE SERVICES "AS IS," "WITH ALL FAULTS" AND "AS AVAILABLE," AND THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
+								TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SPONSOR AND ITS SUPPLIERS MAKE NO REPRESENTATIONS, WARRANTIES OR CONDITIONS, EXPRESS OR IMPLIED. SPONSOR AND ITS SUPPLIERS EXPRESSLY DISCLAIM
+								ANY AND ALL WARRANTIES OR CONDITIONS, EXPRESS, STATUTORY AND IMPLIED, INCLUDING WITHOUT LIMITATION: (A) WARRANTIES OR CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, WORKMANLIKE
+								EFFORT, ACCURACY, TITLE, QUIET ENJOYMENT, NO ENCUMBRANCES, NO LIENS AND NON-INFRINGEMENT; (B) WARRANTIES OR CONDITIONS ARISING THROUGH COURSE OF DEALING OR USAGE OF TRADE; AND (C) WARRANTIES OR
+								CONDITIONS OF UNINTERRUPTED OR ERROR-FREE ACCESS OR USE. NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU THROUGH THE SERVICES OR ANY MATERIALS AVAILABLE THROUGH THE SERVICES
+								WILL CREATE ANY WARRANTY REGARDING ANY SPONSOR ENTITY OR THE SERVICES THAT IS NOT EXPRESSIVELY STATED IN THESE TERMS OF USE. YOU ASSUME ALL RISK FOR ANY DAMAGE THAT MAY RESULT FROM YOUR USE OF
+								OR ACCESS TO THE SERVICES, YOUR DEALING WITH ANY OTHER USER, AND ANY MATERIALS, INCLUDING ALL USER AND SPONSOR MATERIALS, AVAILABLE THROUGH THE SERVICES. YOU UNDERSTAND AND AGREE THAT YOUR USE
+								OF THE SERVICES, AND USE, ACCESS, DOWNLOAD, OR OTHERWISE OBTAINMENT OF MATERIALS THROUGH THE SERVICES AND ANY ASSOCIATED SITES OR SERVICES, ARE AT YOUR OWN DISCRETION AND RISK, AND THAT YOU ARE
+								SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR PROPERTY (INCLUDING YOUR COMPUTER SYSTEM OR MOBILE DEVICE USED IN CONNECTION WITH THE SERVICES), OR THE LOSS OF DATA THAT RESULTS FROM THE USE OF THE
 								SERVICES OR THE DOWNLOAD OR USE OF THOSE MATERIALS. SOME JURISDICTIONS MAY PROHIBIT A DISCLAIMER OR WARRANTIES AND YOU MAY HAVE OTHER RIGHTS THAT VARY FROM JURISDICTION TO JURISDICTION.
 							</p>
 							<p>
-								<b>10. Limitation of Liability/Exclusive Remedy.</b> IN NO EVENT WILL SPONSOR OR ANY OF ITS AFFILIATES BE LIABLE FOR ANY INDIRECT, CONSEQUENTIAL, SPECIAL, INCIDENTAL, OR PUNITIVE DAMAGES (INCLUDING 
-								DAMAGES FOR LOSS OF PROFITS, GOODWILL, OR ANY OTHER INTANGIBLE LOSS) ARISING OUT OF, BASED ON, OR RESULTING FROM THESE TERMS OF USE OR YOUR USE OR ACCESS, OR INABILITY TO USE OR ACCESS, THE 
-								SERVICES OR ANY MATERIALS ON THE SERVICES, WHETHER BASED ON (A) BREACH OF CONTRACT, (B) BREACH OF WARRANTY, (C) NEGLIGENCE, OR (D) ANY OTHER CAUSE OF ACTION, EVEN IF SPONSOR HAS BEEN ADVISED 
-								OF THE POSSIBILITY OF SUCH DAMAGES. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SPONSOR ASSUMES NO LIABILITY OR RESPONSIBILITY FOR ANY (IE) ERRORS, MISTAKES, OR INACCURACIES OF MATERIALS; 
-								(F) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO OR USE OF THE SERVICES; (G) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY 
-								AND ALL PERSONAL INFORMATION STORED THEREIN; (H) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES; (I) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE THAT MAY BE TRANSMITTED 
-								TO OR THROUGH OUR SERVICES BY ANY THIRD PARTY; (J) ANY ERRORS OR OMISSIONS IN ANY MATERIALS OR FOR ANY LOSS OR DAMAGE INCURRED AS A RESULT OF THE USE OF ANY MATERIALS POSTED, EMAILED, 
-								TRANSMITTED, OR OTHERWISE MADE AVAILABLE THROUGH THE SERVICES; AND/OR (K) USER MATERIALS OR THE DEFAMATORY, OFFENSIVE, OR ILLEGAL CONDUCT OF ANY THIRD PARTY. THE AGGREGATE LIABILITY OF SPONSOR 
-								AND ANY OF ITS AFFILIATES TO YOU FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THE USE OF OR INABILITY TO USE ANY PORTION OF THE SERVICES OR OTHERWISE UNDER THESE TERMS OF USE, WHETHER IN 
-								CONTRACT, TORT, OR OTHERWISE, IS LIMITED TO THE GREATER OF: (L) THE AMOUNT YOU HAVE PAID TO SPONSOR FOR THE SERVICES IN THE 12 MONTHS PRIOR TO THE EVENTS OR CIRCUMSTANCES GIVING RISE TO THE 
-								CLAIMS; ANDI (B) $100. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL DAMAGES. ACCORDINGLY, THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU. EACH 
-								PROVISION OF THESE TERMS OF USE THAT PROVIDES FOR A LIMITATION OF LIABILITY, DISCLAIMER OF WARRANTIES, OR EXCLUSION OF DAMAGES IS INTENDED TO AND DOES ALLOCATE THE RISKS BETWEEN THE PARTIES 
+								<b>10. Limitation of Liability/Exclusive Remedy.</b> IN NO EVENT WILL SPONSOR OR ANY OF ITS AFFILIATES BE LIABLE FOR ANY INDIRECT, CONSEQUENTIAL, SPECIAL, INCIDENTAL, OR PUNITIVE DAMAGES (INCLUDING
+								DAMAGES FOR LOSS OF PROFITS, GOODWILL, OR ANY OTHER INTANGIBLE LOSS) ARISING OUT OF, BASED ON, OR RESULTING FROM THESE TERMS OF USE OR YOUR USE OR ACCESS, OR INABILITY TO USE OR ACCESS, THE
+								SERVICES OR ANY MATERIALS ON THE SERVICES, WHETHER BASED ON (A) BREACH OF CONTRACT, (B) BREACH OF WARRANTY, (C) NEGLIGENCE, OR (D) ANY OTHER CAUSE OF ACTION, EVEN IF SPONSOR HAS BEEN ADVISED
+								OF THE POSSIBILITY OF SUCH DAMAGES. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, SPONSOR ASSUMES NO LIABILITY OR RESPONSIBILITY FOR ANY (IE) ERRORS, MISTAKES, OR INACCURACIES OF MATERIALS;
+								(F) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO OR USE OF THE SERVICES; (G) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY
+								AND ALL PERSONAL INFORMATION STORED THEREIN; (H) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICES; (I) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE THAT MAY BE TRANSMITTED
+								TO OR THROUGH OUR SERVICES BY ANY THIRD PARTY; (J) ANY ERRORS OR OMISSIONS IN ANY MATERIALS OR FOR ANY LOSS OR DAMAGE INCURRED AS A RESULT OF THE USE OF ANY MATERIALS POSTED, EMAILED,
+								TRANSMITTED, OR OTHERWISE MADE AVAILABLE THROUGH THE SERVICES; AND/OR (K) USER MATERIALS OR THE DEFAMATORY, OFFENSIVE, OR ILLEGAL CONDUCT OF ANY THIRD PARTY. THE AGGREGATE LIABILITY OF SPONSOR
+								AND ANY OF ITS AFFILIATES TO YOU FOR ALL CLAIMS ARISING OUT OF OR RELATING TO THE USE OF OR INABILITY TO USE ANY PORTION OF THE SERVICES OR OTHERWISE UNDER THESE TERMS OF USE, WHETHER IN
+								CONTRACT, TORT, OR OTHERWISE, IS LIMITED TO THE GREATER OF: (L) THE AMOUNT YOU HAVE PAID TO SPONSOR FOR THE SERVICES IN THE 12 MONTHS PRIOR TO THE EVENTS OR CIRCUMSTANCES GIVING RISE TO THE
+								CLAIMS; ANDI (B) $100. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL DAMAGES. ACCORDINGLY, THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU. EACH
+								PROVISION OF THESE TERMS OF USE THAT PROVIDES FOR A LIMITATION OF LIABILITY, DISCLAIMER OF WARRANTIES, OR EXCLUSION OF DAMAGES IS INTENDED TO AND DOES ALLOCATE THE RISKS BETWEEN THE PARTIES
 								UNDER THESE TERMS. THIS ALLOCATION IS AN ESSENTIAL ELEMENT OF THE AGREEMENT OF THE PARTIES. THE LIMITATIONS IN THIS SECTION WILL APPLY EVEN IF ANY LIMITED REMEDY FAILS ITS ESSENTIAL PURPOSE.
 							</p>
 							<p>
-								<b>11. Choice of Law; Disputes.</b> These Terms of Use are governed by the laws of the State of California, without giving effect to its conflict of laws provisions. You agree to submit to the 
-								personal and exclusive jurisdiction and venue in the state and federal courts sitting in San Francisco, California for any and all disputes, claims and actions arising from or in connection 
-								with the Services and/or these Terms of Use. 
+								<b>11. Choice of Law; Disputes.</b> These Terms of Use are governed by the laws of the State of California, without giving effect to its conflict of laws provisions. You agree to submit to the
+								personal and exclusive jurisdiction and venue in the state and federal courts sitting in San Francisco, California for any and all disputes, claims and actions arising from or in connection
+								with the Services and/or these Terms of Use.
 							</p>
 							<p>
-								<b>12. General.</b> You agree not to export from anywhere any part of the Services provided to you, or any direct product thereof, except in compliance with, and with all licenses and approvals required 
-								under, applicable export laws, rules and regulations. All Services used by the U.S. Government are provided with the commercial license rights described herein. These Terms of Use may only be 
-								amended by a written agreement signed by authorized representatives of the parties to these Terms of Use. If any part of these Terms of Use is determined to be invalid or unenforceable, then 
-								the invalid or unenforceable provision will be replaced with a valid, enforceable provision that most closely matches the intent of the original provision and the remainder of these Terms of Use 
+								<b>12. General.</b> You agree not to export from anywhere any part of the Services provided to you, or any direct product thereof, except in compliance with, and with all licenses and approvals required
+								under, applicable export laws, rules and regulations. All Services used by the U.S. Government are provided with the commercial license rights described herein. These Terms of Use may only be
+								amended by a written agreement signed by authorized representatives of the parties to these Terms of Use. If any part of these Terms of Use is determined to be invalid or unenforceable, then
+								the invalid or unenforceable provision will be replaced with a valid, enforceable provision that most closely matches the intent of the original provision and the remainder of these Terms of Use
 								will continue in effect. The section titles in these Terms of Use are solely used for the convenience of the parties and have no legal or contractual significance. Sponsor may assign this Agreement,
-								in whole or in part, at any time with or without notice to you. You may not assign these Terms of Use, or assign, transfer or sublicense your rights, if any, in the Services. Sponsor failure to act 
-								with respect to a breach by you or others does not waive its right to act with respect to subsequent or similar breaches. Except as expressly stated herein, these Terms of Use, and all expressly 
-								incorporated terms and agreements, constitute the entire agreement between you and Sponsor with respect to the Services and supersede all prior or contemporaneous communications of any kind between 
-								you and Sponsor with respect to the Services. 
+								in whole or in part, at any time with or without notice to you. You may not assign these Terms of Use, or assign, transfer or sublicense your rights, if any, in the Services. Sponsor failure to act
+								with respect to a breach by you or others does not waive its right to act with respect to subsequent or similar breaches. Except as expressly stated herein, these Terms of Use, and all expressly
+								incorporated terms and agreements, constitute the entire agreement between you and Sponsor with respect to the Services and supersede all prior or contemporaneous communications of any kind between
+								you and Sponsor with respect to the Services.
 							</p>
 							<p>
-								<b>13. Consent to Communications.</b> By using the Services, you consent to receiving certain electronic communications from Sponsor as further described in the Privacy Policy. Please read the Privacy Policy 
-								to learn more. You agree that any notices, agreements, disclosures, or other communications that Sponsor sends to you electronically will satisfy any legal communication requirements, including that 
+								<b>13. Consent to Communications.</b> By using the Services, you consent to receiving certain electronic communications from Sponsor as further described in the Privacy Policy. Please read the Privacy Policy
+								to learn more. You agree that any notices, agreements, disclosures, or other communications that Sponsor sends to you electronically will satisfy any legal communication requirements, including that
 								those communications be in writing.
 							</p>
 							<p>
-								<b>14. Contact Information and License Disclosures.</b> The Services are offered by Coalition to Preserve LA (www.2preservela.org) and New Livable California 
-								(<a href="https://www.livablecalifornia.org/" target="_blank">https://www.livablecalifornia.org/</a>) (together, “Sponsor”). 
-								You may contact Sponsor by email to: <a href= "mailto: contact@livableca.org" target="_blank">contact@livableca.org</a>. 
+								<b>14. Contact Information and License Disclosures.</b> The Services are offered by Coalition to Preserve LA (www.2preservela.org) and New Livable California
+								(<a href="https://www.livablecalifornia.org/" target="_blank">https://www.livablecalifornia.org/</a>) (together, “Sponsor”).
+								You may contact Sponsor by email to: <a href= "mailto: contact@livableca.org" target="_blank">contact@livableca.org</a>.
 							</p>
-							
+
 						</div>
 					</div>
 				</div>
 			</div>
 		</div>
-	
+
 		<section id="banner" style="padding-top: 1em; padding-bottom: 1em;">
 			<h1>Will SB 50 Wipe Out Your Neighborhood?</h1>
 		</section>
@@ -408,7 +408,7 @@
 		<section class="wrapper" style="padding-top: 1em; padding-bottom: 0; color: black;">
 			<div class="inner">
 				<p>
-					SB 50 is an unprecedented law that will destroy thousands of homes & apartments to build luxury housing up to 8 stories high. <b>Are YOU in the SB 50 Demolition Derby? SEARCH & SHARE this SB 50 Map</b>. If you're in a 
+					SB 50 is an unprecedented law that will destroy thousands of homes & apartments to build luxury housing up to 8 stories high. <b>Are YOU in the SB 50 Demolition Derby? SEARCH & SHARE this SB 50 Map</b>. If you're in a
 					Yellow, Blue or Red zone, call your legislator (<font class="act-now-link" style="color: -webkit-link;cursor: pointer;text-decoration: underline;">here</font>), and get on social media & slam SB 50!
 				</p>
 				<p style="font-weight:700;text-align: left;">
@@ -463,13 +463,13 @@
 		</div>
 
 		<div class="inner" style="padding-top:1.5em;">
-		
+
 			<p>
-				Written by legislator Scott Wiener, SB 50 rewards developers to buy and demolish single-family housing and apartments near rail, train, ferry or busy bus stops AND near jobs and good schools. 
-				SB 50 kills local planning rules, letting buildings tower over homes. The towers can include NO parking, NO space for trees, NO setbacks, and NO design standards. All that developers must do is 
+				Written by legislator Scott Wiener, SB 50 rewards developers to buy and demolish single-family housing and apartments near rail, train, ferry or busy bus stops AND near jobs and good schools.
+				SB 50 kills local planning rules, letting buildings tower over homes. The towers can include NO parking, NO space for trees, NO setbacks, and NO design standards. All that developers must do is
 				include a few "affordable" rental units.
 			</p>
-		
+
 			<h2 style="text-align: center;"> FAQs </h2>
 
 			<p style="font-weight:600;font-style:italic;margin:0 0 0.5em 0;color:#5292f9;font-size: 18px;">
@@ -521,8 +521,8 @@
 				cost. It is unlikely that residents of San Diego know that their communities would be up-zoned to apartment towers under SB 50, merely because they wanted better bus service.
 			</p>
 			<p>
-				*The opaque wording of SB 50 says that developers can select up to 3 exemptions and waivers from planning and zoning standards. But the San Francisco Planning Department, California's most expert, said that on closer reading, they believe the 
-				bill authorizes developers to claim up to 6 exemptions from planning and zoning standards. 
+				*The opaque wording of SB 50 says that developers can select up to 3 exemptions and waivers from planning and zoning standards. But the San Francisco Planning Department, California's most expert, said that on closer reading, they believe the
+				bill authorizes developers to claim up to 6 exemptions from planning and zoning standards.
 			</p>
 
 		</div>


### PR DESCRIPTION
Per
https://www.pewresearch.org/fact-tank/2018/09/06/the-american-middle-class-is-stable-in-size-but-losing-ground-financially-to-upper-income-families/,
the middle class is adults making 2/3 to double the US median
household income, a range from $45,200 to $135,600.

Per slide 5 of the California Association of Realtors presentation
at https://www.car.org/en/marketdata/data/haitraditional, the income
required to afford the median single family home in California is
$122,340. This is at the very high end of the middle income range.
It's also a stark contrast with the income required to afford the
median US single family home, $55,850, a number I would quote as "widely available to the middle class."

Given these statistics and income requirements I don't think it's fair
to categorize single family home neighborhoods as "middle class." The
residents are either upper class (if they are moving in now) or have
built a significant amount of equity in their homes through supply restrictions.